### PR TITLE
Updated switchuser to be compatible with django 1.9

### DIFF
--- a/django_switchuser/middleware.py
+++ b/django_switchuser/middleware.py
@@ -1,7 +1,7 @@
 import sys
 
 from django.conf import settings as s
-from django.utils.importlib import import_module
+from importlib import import_module
 
 class SuStateMiddleware(object):
     su_state_fqcn = getattr(s, "SU_STATE_CLASS", "django_switchuser.state.SuState")


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-9

> `django.utils.importlib will be removed.`
